### PR TITLE
Bug Fix: Clones Spawning When Disconnecting from You Died Screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v3.3.3
+
+## Bug Fixes
+- Fixed a bug that caused a crash when launch alongside Towny.
+- Unified and updated version number to 3.3.3.
+- Fixed clones spawning from dead players logging off.
+
 # v3.3.2
 
 ## Bug Fixes

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'de.snap20lp.offlineplayers'
-version '3.3.2'
+version '3.3.3'
 
 repositories {
     maven { url = 'https://repo.md-5.net/content/groups/public' }

--- a/src/main/java/de/snap20lp/offlineplayers/CloneManager.java
+++ b/src/main/java/de/snap20lp/offlineplayers/CloneManager.java
@@ -226,6 +226,7 @@ public class CloneManager implements Listener { // todo: Perhaps refactor events
     @EventHandler
     public void on(PlayerQuitEvent playerQuitEvent) {
         Player quitPlayer = playerQuitEvent.getPlayer();
+        if (quitPlayer.getHealth() <= 0) return;
         FileConfiguration config = OfflinePlayers.getInstance().getConfig();
         if (config.getStringList("OfflinePlayer.worldBlacklist").contains(quitPlayer.getWorld().getName())) return;
         if (config.getStringList("OfflinePlayer.game-modeBlacklist").contains(quitPlayer.getGameMode().name())) return;

--- a/src/main/java/de/snap20lp/offlineplayers/EventProtector.java
+++ b/src/main/java/de/snap20lp/offlineplayers/EventProtector.java
@@ -1,11 +1,5 @@
 package de.snap20lp.offlineplayers;
 
-import com.onarandombox.multiverseinventories.MultiverseInventories;
-import com.onarandombox.multiverseinventories.profile.PlayerProfile;
-import com.onarandombox.multiverseinventories.share.Sharables;
-import com.palmergames.bukkit.towny.TownyAPI;
-import com.palmergames.bukkit.towny.exceptions.TownyException;
-import com.palmergames.bukkit.towny.object.Town;
 import de.snap20lp.offlineplayers.depends.APIManager;
 import de.snap20lp.offlineplayers.depends.MultiverseInventoriesFacade;
 import de.snap20lp.offlineplayers.depends.TownyFacade;
@@ -16,7 +10,6 @@ import org.bukkit.Location;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.inventory.ItemStack;
 
 /**
  * The Event Protector module prevents players from accidentally leaving their offline player in a WorldGuard protected

--- a/src/main/java/de/snap20lp/offlineplayers/depends/TownyFacade.java
+++ b/src/main/java/de/snap20lp/offlineplayers/depends/TownyFacade.java
@@ -3,7 +3,6 @@ package de.snap20lp.offlineplayers.depends;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Town;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
@@ -24,7 +23,7 @@ public class TownyFacade {
      * Creates a new TownyFacade by grabbing the TownyAPI.
      */
     public TownyFacade () {
-        townyAPI = (TownyAPI) Bukkit.getPluginManager().getPlugin("Towny");
+        townyAPI = TownyAPI.getInstance();
     }
 
     /**

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: OfflinePlayers
-version: 3.1.2
+version: 3.3.3
 authors:
   - snap20lp
   - Sugaku


### PR DESCRIPTION
# v3.3.3

## Bug Fixes
- Fixed a bug that caused a crash when launch alongside Towny.
- Unified and updated version number to 3.3.3.
- Fixed clones spawning from dead players logging off.

Closes #7. 